### PR TITLE
Updated install AHK to deal with install and upgrade

### DIFF
--- a/tools/veracryptInstall.ahk
+++ b/tools/veracryptInstall.ahk
@@ -3,23 +3,39 @@
 ; #Warn  ; Enable warnings to assist with detecting common errors.
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+SetTitleMatchMode, 1
 
+winTitleInstall = VeraCrypt Setup
 
-WinWait, VeraCrypt Setup 1.19, , 60
+WinWait, %winTitleInstall%, , 300
 WinActivate
-BlockInput On
-Send !a
-Send !n
-Send !n
-Send !i
-BlockInput Off
-WinWait, VeraCrypt Setup ahk_class #32770
-WinActivate
-IfWinActive
-	Send {Enter}
-Sleep, 100
-Send !f
-WinWait, VeraCrypt Setup ahk_class #32770
-WinActivate
-IfWinActive
-	Send !n
+BlockInput, Off
+
+; License terms
+ControlClick, I &accept the license terms, %winTitleInstall%,,,, NA
+ControlClick, &Next >, %winTitleInstall%,,,, NA
+
+; Type of install
+ControlClick, &Next >, %winTitleInstall%,,,, NA
+
+; Upgrade or Install
+IfWinExist, %winTitleInstall%, upgraded in the location,,
+	ControlClick, Upgrade, %winTitleInstall%,,,, NA
+else
+	ControlClick, &Install, %winTitleInstall%,,,, NA
+
+; Wait until the install process is finished
+WinWait, %winTitleInstall% ahk_class #32770
+ControlClick, OK, %winTitleInstall%,,,, NA
+
+; Donation
+IfWinExist, %winTitleInstall%, VeraCrypt has been successfully
+	ControlClick, &Finish, %winTitleInstall%
+
+; Help / manual suggestion	
+IfWinExist, %winTitleInstall%, If you have never used VeraCrypt before
+	ControlClick, &No, %winTitleInstall%
+
+; If doing an upgrade you are prompted to restart
+IfWinExist, %winTitleInstall%, computer must be restarted
+	ControlClick, &No, %winTitleInstall%


### PR DESCRIPTION
I've updated the install AHK to deal with installation and upgrades. I believe the main problem with this failing automated testing is that the autohotkey script was run in the background and then the VeraCrypt install files were downloaded which was so slow that by the time I got them the autohotkey script had timed out and terminated.

The autohotkey timeout was set at 60 seconds. I've changed this to 300 seconds. Other changes to to tidy it up and work with both upgrades and installs.