### PR TITLE
Update veracryptInstall.ahk

### DIFF
--- a/tools/veracryptInstall.ahk
+++ b/tools/veracryptInstall.ahk
@@ -6,60 +6,148 @@ SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 SetTitleMatchMode, 1
 SetControlDelay -1
 
-winTitleInstall = VeraCrypt Setup
 upgradeVeraCrypt = 0
 
-WinWait, %winTitleInstall%, , 300
-WinActivate
-; BlockInput, Off
+; This title is only used in the language selection window
+winWizzardTitle := []
+winWizzardTitle["en"] := "VeraCrypt Setup"
+winWizzardTitle["de"] := "VeraCrypt-Einrichtungsassistent"
+winWizzardTitle["fr"] := "Assistant d'installation de VeraCrypt"
 
-; Language selection
-ControlClick, OK, %winTitleInstall%,,,, NA
+winWizzardText := []
+winWizzardText["en"] := "language"
+winWizzardText["de"] := "Sprache"
+winWizzardText["fr"] := "langue"
 
-; License terms
-WinWait, %winTitleInstall%, license
-ControlClick, I &accept the license terms, %winTitleInstall%,,,, NA
-ControlClick, &Next >, %winTitleInstall%,,,, NA
+; Title for all other windows, maybe this is different in other languages?
+winInstallTitle := []
+winInstallTitle["en"] := "VeraCrypt Setup"
+winInstallTitle["de"] := "VeraCrypt Setup"
+winInstallTitle["fr"] := "VeraCrypt Setup"
 
-; Type of install
-WinWait, %winTitleInstall%, Wizard Mode, , 2
-if !(ErrorLevel) {
-	ControlClick, &Next >, %winTitleInstall%,,,, NA
+; License window seems to be always in english
+winLicenseText := []
+winLicenseText["en"] := "Please read the license terms"
+winLicenseText["de"] := "Please read the license terms"
+winLicenseText["fr"] := "Please read the license terms"
+
+winLicenseCheckBox := []
+winLicenseCheckBox["en"] := "I &accept the license terms"
+winLicenseCheckBox["de"] := "I &accept the license terms"
+winLicenseCheckBox["fr"] := "I &accept the license terms"
+
+winInstallTypeText := []
+winInstallTypeText["en"] := "Wizard Mode"
+winInstallTypeText["de"] := "Installationsassisten"
+winInstallTypeText["fr"] := "Mode assistant"
+
+winInstallOptionsText := []
+winInstallOptionsText["en"] := "upgraded in the location"
+winInstallOptionsText["de"] := "Geben Sie das Zielverzeichnis"
+winInstallOptionsText["fr"] := "ou saisir l'emplacement"
+
+winDonationText := []
+winDonationText["en"] := "donation"
+winDonationText["de"] := "Spende"
+winDonationText["fr"] := "Veuillez envisager de faire un don"
+
+; Restart window only apears on software update,
+; and there is no language selection. thats why all english
+winRestartText := []
+winRestartText["en"] := "computer must be restarted"
+winRestartText["de"] := "computer must be restarted"
+winRestartText["fr"] := "computer must be restarted"
+
+winHelpText := []
+winHelpText["en"] := "If you have never used VeraCrypt before"
+winHelpText["de"] := "Falls Sie VeraCrypt noch nie zuvor verwendet haben"
+winHelpText["fr"] := "Si vous n'avez jamais utilis"
+
+language = en
+time := A_Now
+time+= 60
+
+findFirstWindow:
+Loop
+{
+	; search for the language wizzard window
+	; this only shows up on first install and is skiped if the software is already installed
+	for key, value in winWizzardTitle
+	{
+		IfWinExist, %value%, % winWizzardText[key],,
+		{
+			language = %key%
+			break findFirstWindow
+		}
+	}
+	; search for the license window
+	; if this is found, the setup will update the software
+	; the language seems to be always english
+	for key, value in winInstallTitle
+	{
+		IfWinExist, %value%, % winLicenseText[key],,
+		{
+			language = en
+			upgradeVeraCrypt = 1
+			break findFirstWindow
+		}
+	}
+	Sleep, 100
+	if (A_Now = time)
+		break findFirstWindow
 }
 
+
+;MsgBox % "Language selection"
+if (! upgradeVeraCrypt) {
+	WinActivate, % winWizzardTitle[language],,,
+	ControlClick, Button1, % winWizzardTitle[language],,,, NA
+}
+
+
+;MsgBox % "License terms"
+WinWait, % winInstallTitle[language], % winLicenseText[language]
+ControlClick, Button5, % winInstallTitle[language], % winLicenseText[language],,, NA
+ControlClick, Button3, % winInstallTitle[language], % winLicenseText[language],,, NA
+
+
+;MsgBox % "Type of install"
+WinWait, % winInstallTitle[language], % winInstallTypeText[language], , 2
+if !(ErrorLevel) {
+	ControlClick, Button3, % winInstallTitle[language],,,, NA
+}
 Sleep, 200
 
-; Upgrade or Install
-IfWinExist, %winTitleInstall%, upgraded in the location,,
-{
-	ControlClick, Upgrade, %winTitleInstall%,,,, NA
-	upgradeVeraCrypt = 1
-}
-else
-	ControlClick, &Install, %winTitleInstall%,,,, NA
 
-; Wait until the install process is finished
-WinWait, %winTitleInstall% ahk_class #32770
-ControlClick, OK, %winTitleInstall%,,,, NA
+;MsgBox % "Upgrade/Install"
+WinWait, % winInstallTitle[language], % winInstallOptionsText[language],,
+ControlClick, Button3, % winInstallTitle[language],,,, NA
 
-; Donation
-WinWait, %winTitleInstall%, donation, , 10
+
+;MsgBox % "Wait until the install process is finished"
+WinWait, % winInstallTitle[language] " ahk_class #32770"
+ControlClick, Button1, % winInstallTitle[language] " ahk_class #32770",,,, NA
+
+
+;MsgBox % "Donation"
+WinWait, % winInstallTitle[language], % winDonationText[language], , 10
 if !(ErrorLevel) {
 	Sleep, 200
-	ControlClick, &Finish, %winTitleInstall%,,,, NA
+	ControlClick, Button3, % winInstallTitle[language],,,, NA
 }
 
-; If doing an upgrade you are prompted to restart
+
+;MsgBox % "If doing an upgrade you are prompted to restart"
 if (upgradeVeraCrypt) {
-	WinWait, %winTitleInstall%, computer must be restarted, , 2
+	WinWait, % winInstallTitle[language], % winRestartText[language], , 2
 	if !(ErrorLevel) {
-		ControlClick, &No, %winTitleInstall%,,,, NA
+		ControlClick, Button2, % winInstallTitle[language], % winRestartText[language],,, NA
 	}
 }
 else {
-	; Help / manual suggestion	
-	WinWait, %winTitleInstall%, If you have never used VeraCrypt before, , 2
+	;MsgBox % "Help / manual suggestion"
+	WinWait, % winInstallTitle[language], % winHelpText[language], , 2
 	if !(ErrorLevel) {
-		ControlClick, &No, %winTitleInstall%,,,, NA
+		ControlClick, Button2, % winInstallTitle[language], % winHelpText[language],,, NA
 	}
 }


### PR DESCRIPTION
Some window names, buttons and text is different on other languages.
Update the script for multi language (en de fr). Should be easy to extend for more, just add stuff into the translation arrays.
