### PR TITLE
Allow spaces in ahk file path

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -20,7 +20,7 @@ $packageArgs = @{
 $ahkExe = 'AutoHotKey'
 $ahkFile = Join-Path $toolsDir "veracryptInstall.ahk"
 $ahkProc = Start-Process -FilePath $ahkExe `
-                         -ArgumentList $ahkFile `
+                         -ArgumentList "`"$ahkFile`"" `
                          -PassThru
 
 $ahkId = $ahkProc.Id

--- a/tools/chocolateyUninstall.ps1
+++ b/tools/chocolateyUninstall.ps1
@@ -18,7 +18,7 @@ $ahkRun = "$Env:Temp\$(Get-Random).ahk"
 
 Copy-Item $ahkFile "$ahkRun" -Force
 $ahkProc = Start-Process -FilePath 'AutoHotKey' `
-					   -ArgumentList $ahkRun `
+					   -ArgumentList "`"$ahkRun`"" `
 					   -PassThru
 Write-Debug "$ahkRun start time:`t$($ahkProc.StartTime.ToShortTimeString())"
 Write-Debug "$ahkRun process ID:`t$($ahkProc.Id)"


### PR DESCRIPTION
If the Windows username contains spaces, the ahk path at uninstall will look something like:

```
C:\Users\Spaced Username\AppData\Local\Temp\chocolatey\1388457550.ahk
```

This gets interpreted as `['C:\Users\Spaced', 'Username...']` by the time it reaches AutoHotKey and raises an error that the script file does not exist.